### PR TITLE
Add basic build helper and update x86 build flags

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Build helper script for the hazelnut microkernel tree.
+# Usage: ./build.sh [kernel|apps|all]
+# Default is 'all'.
+set -e
+ROOT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+build_kernel() {
+    echo "==> Building kernel"
+    (cd "$ROOT_DIR/kernel" && \
+        make ARCH=x86 PLATFORM=i686 -k || true)
+}
+
+build_apps() {
+    echo "==> Building user applications"
+    (cd "$ROOT_DIR/apps" && \
+        make ARCH=x86 PLATFORM=i686 -k || true)
+}
+
+case "$1" in
+    kernel)
+        build_kernel
+        ;;
+    apps)
+        build_apps
+        ;;
+    all|"")
+        build_kernel
+        build_apps
+        ;;
+    *)
+        echo "Usage: $0 [kernel|apps|all]" >&2
+        exit 1
+        ;;
+esac
+

--- a/kernel/Makeconf
+++ b/kernel/Makeconf
@@ -133,11 +133,11 @@ endif
 
 ifeq ($(ARCH), x86)
   ifneq ($(shell type -p i686-linux-gcc),)
-PREFIX		=i686-linux-
+PREFIX          = i686-linux-
   endif
-CFLAGS		+= -Wall -Wno-format -O9 -fomit-frame-pointer -freg-struct-return
+CFLAGS          += -Wall -Wno-format -O2 -fomit-frame-pointer -freg-struct-return -m32
+LDFLAGS         += -m elf_i386
 endif
-
 ######################################################################
 # tools
 

--- a/kernel/xconfig/tkgen.c
+++ b/kernel/xconfig/tkgen.c
@@ -96,6 +96,8 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
 #include "tkparse.h"
 
 


### PR DESCRIPTION
## Summary
- add a simple build helper script to build kernel and apps
- fix `tkgen.c` warnings by including missing headers
- update x86 section of `Makeconf` with 32‑bit flags and linker mode

## Testing
- `./build.sh kernel` *(fails: invalid command name "button")*

------
https://chatgpt.com/codex/tasks/task_e_688a4c3689648331afff6a80c77b8296