### PR TITLE
Address code review feedback

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,5 +9,10 @@ if [ ! -f kernel/xconfig/.config ]; then
   cp kernel/xconfig/defconfig kernel/xconfig/.config
 fi
 
-make -C kernel
-make -C apps
+if [ $# -eq 0 ]; then
+  make -C kernel
+  make -C apps
+else
+  make -C kernel "$@"
+  make -C apps "$@"
+fi

--- a/kernel/include/x86/memory.h
+++ b/kernel/include/x86/memory.h
@@ -15,6 +15,7 @@
 
 #include INC_ARCH(config.h)
 #include INC_ARCH(mapping.h)
+#include <stdint.h>
 
 #if defined(ASSEMBLY)
 # define __DWORD_CAST
@@ -165,7 +166,7 @@ INLINE void set_current_pagetable(ptr_t pdir)
 void small_space_to_large (space_t *);
 int make_small_space (space_t *, byte_t);
 
-INLINE dword_t get_ipc_copy_limit(dword_t addr, tcb_t *receiver)
+INLINE uintptr_t get_ipc_copy_limit(uintptr_t addr, tcb_t *receiver)
 {
     if ( addr < SMALL_SPACE_START )
 	/* Sender is in small space.  Use receivers pagetab. */
@@ -181,7 +182,7 @@ INLINE dword_t get_ipc_copy_limit(dword_t addr, tcb_t *receiver)
 	return MEM_COPYAREA_END;
 }
 
-INLINE void check_limit(dword_t addr, dword_t limit, tcb_t *tcb)
+INLINE void check_limit(uintptr_t addr, uintptr_t limit, tcb_t *tcb)
 {
     if ( addr >= limit )
 	if ( limit <= SMALL_SPACE_START )

--- a/tools/mktime.c
+++ b/tools/mktime.c
@@ -4,7 +4,7 @@
 
 #define is_good_m(x) ((x) < (1 << M_BITS))
 
-#define best_m1(x)	(x)
+#define best_m1(x)      ((x))
 #define best_m2(x)	(is_good_m(x) ? (x) : best_m1((x)>>2))
 #define best_m3(x)	(is_good_m(x) ? (x) : best_m2((x)>>2))
 #define best_m4(x)	(is_good_m(x) ? (x) : best_m3((x)>>2))


### PR DESCRIPTION
## Summary
- allow passing arguments to build helper
- parenthesize the best_m1 macro
- fix pointer-to-int casts in IPC code
- make IPC helper prototypes use `uintptr_t`

## Testing
- `./build.sh` *(fails: target file 'clean' has both : and :: entries)*

------
https://chatgpt.com/codex/tasks/task_e_688a86fabb0c8331a81b72f041a30a27

## Summary by Sourcery

Apply code review feedback to improve type safety in IPC code, refine a macro, and enhance the build script.

Bug Fixes:
- Parenthesize the best_m1 macro to ensure correct evaluation

Enhancements:
- Include stdint.h and replace pointer-to-int casts in IPC code with uintptr_t/intptr_t
- Update IPC helper prototypes (get_ipc_copy_limit and check_limit) to use uintptr_t

Build:
- Modify build.sh to forward command-line arguments to kernel and apps make targets